### PR TITLE
fbwikka: custom handler for 'rawlist'

### DIFF
--- a/handlers/rawlist/rawlist.php
+++ b/handlers/rawlist/rawlist.php
@@ -3,18 +3,36 @@
  * FreeBASIC wikka custom handler
  * 
  * Display a raw list version of a wiki index page in a plain format
- * Pages supported:
+ *
+ * Usage:
+ *    wikka.php?wakka=<pagename>/rawlist
+ *    wikka.php?wakka=<pagename>/rawlist&format=list
+ *    wikka.php?wakka=<pagename>/rawlist&format=index
+ *
+ * <pagname>, follow pages allowed:
  *    - PageIndex
  *    - RecentChanges
  *
- * Header Output format is:
+ * Optional Parameters:
+ *    format=list             plain list (default if not specified)
+ *    format=index            Output index format
+ *
+ * format=list output format, one entry per line:
+ *    pagename . EOL
+ * 
+ * format=index output format:
+ *    Index-Header
+ *    Index-Entry...
+ *  
+ * Index-Header:
  *   # freebasic wiki index
  *   # index: PageIndex
  *   # source: https://www.freebasic.net/wiki/wikka.php?wakka=
  *   # count: nnnn
  *   
- * Data output format is one page name per line:
+ * Index-Entry, one per line:
  *    id . TAB . pagename . EOL
+ *
  */
 
 // Send page as UTF-8 in cases where webserver is set up for different char set.
@@ -22,6 +40,19 @@ header('Content-Type: text/plain; charset=utf-8');
 
 if ($this->HasAccess('read') && $this->page)
 {
+
+	$format = 'list';
+
+	// &format=list or $format=index specified?
+	if (isset($_GET['format']))
+	{
+		$a = $this->GetSafeVar('format', 'get');
+		if ($a == 'list' || $a == 'index' )
+		{
+			$format = $a;
+		}
+	}
+	
 	/*
 	 * Use the page name (tag) to determine what to do here.  Even though
 	 * any page could potentially have the {{PageIndex}} and {{RecentChanges}}
@@ -47,12 +78,15 @@ if ($this->HasAccess('read') && $this->page)
 		$pages = NULL;
 	}
 
-	// output header
-	print( "# freebasic wiki index\r\n" );
-	print( "# index: " . $this->tag . "\r\n" );
-	print( "# source: " . $this->wikka_url . "\r\n" );
-	print( "# count: " . count( $pages) . "\r\n" );
-	
+	if ($format == 'index')
+	{
+		// output header
+		print( "# freebasic wiki index\r\n" );
+		print( "# index: " . $this->tag . "\r\n" );
+		print( "# source: " . $this->wikka_url . "\r\n" );
+		print( "# count: " . count( $pages) . "\r\n" );
+	}
+
 	// any results?
 	if( $pages )
 	{
@@ -64,7 +98,14 @@ if ($this->HasAccess('read') && $this->page)
 			{
 				continue;
 			}
-			print( $page['id'] . "\t" . $page['tag']. "\r\n" );
+			if ($format == 'index')
+			{
+				print( $page['id'] . "\t" . $page['tag']. "\r\n" );
+			}
+			else
+			{
+				print( $page['tag']. "\r\n" );
+			}
 		}
 	}
 }

--- a/handlers/rawlist/rawlist.php
+++ b/handlers/rawlist/rawlist.php
@@ -1,11 +1,20 @@
 <?php
 /**
  * FreeBASIC wikka custom handler
- * Display a raw list version of a wiki page, i.e. the with no formatting.
+ * 
+ * Display a raw list version of a wiki index page in a plain format
  * Pages supported:
- * - PageIndex
- * - RecentChanges
+ *    - PageIndex
+ *    - RecentChanges
  *
+ * Header Output format is:
+ *   # freebasic wiki index
+ *   # index: PageIndex
+ *   # source: https://www.freebasic.net/wiki/wikka.php?wakka=
+ *   # count: nnnn
+ *   
+ * Data output format is one page name per line:
+ *    id . TAB . pagename . EOL
  */
 
 // Send page as UTF-8 in cases where webserver is set up for different char set.
@@ -13,34 +22,49 @@ header('Content-Type: text/plain; charset=utf-8');
 
 if ($this->HasAccess('read') && $this->page)
 {
+	/*
+	 * Use the page name (tag) to determine what to do here.  Even though
+	 * any page could potentially have the {{PageIndex}} and {{RecentChanges}}
+	 * actions, historically these actions have only ever been on the
+	 * PageIndex and RecentChanges pages, respectively.  That probably won't
+	 * change anytime soon.
+	 */
+
+	$qry = "SELECT DISTINCT id, tag
+			FROM " . $this->GetConfigValue('table_prefix') . "pages
+			WHERE latest = 'Y'";
+	
 	if ($this->GetPageTag() == 'PageIndex')
 	{
-		if( $pages = $this->LoadPageTitles() )
-		{
-			foreach ($pages as $page)
-			{
-				// check user read privileges
-				if (!$this->HasAccess('read', $page['tag']))
-				{
-					continue;
-				}
-				print($page['tag'] . "\r\n" );
-			}
-		}
+		$pages = $this->LoadAll( $qry . " ORDER BY tag" );
 	}
 	elseif ($this->GetPageTag() == 'RecentChanges')
 	{
-		if( $pages = $this->LoadRecentlyChanged() )
+		$pages = $this->LoadAll( $qry . " ORDER BY id DESC" );
+	}
+	else
+	{
+		$pages = NULL;
+	}
+
+	// output header
+	print( "# freebasic wiki index\r\n" );
+	print( "# index: " . $this->tag . "\r\n" );
+	print( "# source: " . $this->wikka_url . "\r\n" );
+	print( "# count: " . count( $pages) . "\r\n" );
+	
+	// any results?
+	if( $pages )
+	{
+		// output index
+		foreach ($pages as $page)
 		{
-			foreach ($pages as $page)
+			// check user read privileges
+			if (!$this->HasAccess('read', $page['tag']))
 			{
-				// check user read privileges
-				if (!$this->HasAccess('read', $page['tag']))
-				{
-					continue;
-				}
-				print($page['tag'] . "\r\n" );
+				continue;
 			}
+			print( $page['id'] . "\t" . $page['tag']. "\r\n" );
 		}
 	}
 }

--- a/handlers/rawlist/rawlist.php
+++ b/handlers/rawlist/rawlist.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * FreeBASIC wikka custom handler
+ * Display a raw list version of a wiki page, i.e. the with no formatting.
+ * Pages supported:
+ * - PageIndex
+ * - RecentChanges
+ *
+ */
+
+// Send page as UTF-8 in cases where webserver is set up for different char set.
+header('Content-Type: text/plain; charset=utf-8');
+
+if ($this->HasAccess('read') && $this->page)
+{
+	if ($this->GetPageTag() == 'PageIndex')
+	{
+		if( $pages = $this->LoadPageTitles() )
+		{
+			foreach ($pages as $page)
+			{
+				// check user read privileges
+				if (!$this->HasAccess('read', $page['tag']))
+				{
+					continue;
+				}
+				print($page['tag'] . "\r\n" );
+			}
+		}
+	}
+	elseif ($this->GetPageTag() == 'RecentChanges')
+	{
+		if( $pages = $this->LoadRecentlyChanged() )
+		{
+			foreach ($pages as $page)
+			{
+				// check user read privileges
+				if (!$this->HasAccess('read', $page['tag']))
+				{
+					continue;
+				}
+				print($page['tag'] . "\r\n" );
+			}
+		}
+	}
+}
+?>

--- a/libs/Wakka.class.php
+++ b/libs/Wakka.class.php
@@ -5141,6 +5141,12 @@ class Wakka
 			header('Content-type: text/plain');
 			print($this->handler($this->GetHandler()));
 		}
+		// list page handler
+		elseif ($this->GetHandler() == 'rawlist')
+		{
+			header('Content-type: text/plain');
+			print($this->handler($this->GetHandler()));
+		}
 		// grabcode page handler
 		elseif ($this->GetHandler() == 'grabcode')
 		{


### PR DESCRIPTION
This custom handler provides a list of pages (index) in a raw format, free from any HTML formatting.

Purpose is to provide an efficient method for fbdoc tools to obtain a page list from the wiki.

- supported by PageIndex and RecentChanges wiki pages only
- the handler outputs the list of wiki page names in a plain format

Proposed usage:
`https://www.freebasic.net/wiki/wikka.php?wakka=PageIndex/rawlist`
`https://www.freebasic.net/wiki/wikka.php?wakka=RecentChanges/rawlist`

Currently, FreeBASIC's fbdoc tool `getindex` obtains an index of all the wiki pages by fetching the wiki's PageIndex page in HTML format.  The HTML formatted download is more than 300 KB.  After stripping the HTML tags to extract the page names, the actual data is less than 20KB.

----
A useful extension to this may be:
- Also write the page ID (which increments every time the page is changed) with each page name
- by comparing a locally saved index with a newly fetched index, it would be possible to determine which pages have changed, and then fetch only those pages.  A full download ( 3 MB+) of all pages from the wiki takes quite a while and stresses the server needlessly if it can be easily determined only a few pages need to be updated locally.
