### PR TITLE
Fix logic for generating html page titles to handle leading underscores

### DIFF
--- a/actions/pageindex/pageindex.php
+++ b/actions/pageindex/pageindex.php
@@ -105,7 +105,7 @@ else
                 // Output page title if $showpagetitle set to 1
                 if (TRUE === $showpagetitle)
                 {
-                    $index_output .= " <span class=\"pagetitle\">[".$this->PageTitle($page['tag'])."]</span>";
+                    $index_output .= " <span class=\"pagetitle\">[".$this->PageTitleHTML($page['tag'])."]</span>";
                 }
                 if ($cached_username == $page_owner)
                 {

--- a/actions/textsearch/textsearch.php
+++ b/actions/textsearch/textsearch.php
@@ -60,7 +60,7 @@ if ($results)
 		if ($this->HasAccess('read',$page['tag']))
 		{
 			$total_results++;
-			$result_page_list .= '<li>'.$this->Link($page['tag']).' &mdash; '.$this->PageTitle($page['tag']).'</li>'."\n";	// @@@ make new array and let new array2list methods do the formatting
+			$result_page_list .= '<li>'.$this->Link($page['tag']).' &mdash; '.$this->PageTitleHTML($page['tag']).'</li>'."\n";	// @@@ make new array and let new array2list methods do the formatting
 		}
 	}
 }

--- a/actions/textsearch/textsearch.php
+++ b/actions/textsearch/textsearch.php
@@ -60,7 +60,7 @@ if ($results)
 		if ($this->HasAccess('read',$page['tag']))
 		{
 			$total_results++;
-			$result_page_list .= '<li>'.$this->Link($page['tag']).'</li>'."\n";	// @@@ make new array and let new array2list methods do the formatting
+			$result_page_list .= '<li>'.$this->Link($page['tag']).' &mdash; '.$this->PageTitle($page['tag']).'</li>'."\n";	// @@@ make new array and let new array2list methods do the formatting
 		}
 	}
 }

--- a/actions/textsearchexpanded/textsearchexpanded.php
+++ b/actions/textsearchexpanded/textsearchexpanded.php
@@ -126,7 +126,7 @@ if ($results)
 				$highlightMatch = preg_replace('/('.$this->htmlspecialchars_ent($phrase_re).')/i','<<$1>>',$text,-1); // -1 = no limit (default!)
 			}
 			$matchText = "&hellip;".str_replace(array('<<', '>>'), array('<span class="tse_keywords">', '</span>'), $highlightMatch)."&hellip;";
-			$result_page_list .= "\n<li>".$this->Link($page["tag"])." &mdash; ".$page['time'];
+			$result_page_list .= "\n<li>".$this->Link($page["tag"]).' &mdash; '.$this->PageTitle($page['tag'])." &mdash; ".$page['time'];
 			$result_page_list .= "\n<blockquote>".$matchText."</blockquote>\n";
 			$result_page_list .= "\n</li>\n";
 		}

--- a/actions/textsearchexpanded/textsearchexpanded.php
+++ b/actions/textsearchexpanded/textsearchexpanded.php
@@ -126,7 +126,7 @@ if ($results)
 				$highlightMatch = preg_replace('/('.$this->htmlspecialchars_ent($phrase_re).')/i','<<$1>>',$text,-1); // -1 = no limit (default!)
 			}
 			$matchText = "&hellip;".str_replace(array('<<', '>>'), array('<span class="tse_keywords">', '</span>'), $highlightMatch)."&hellip;";
-			$result_page_list .= "\n<li>".$this->Link($page["tag"]).' &mdash; '.$this->PageTitle($page['tag'])." &mdash; ".$page['time'];
+			$result_page_list .= "\n<li>".$this->Link($page["tag"]).' &mdash; '.$this->PageTitleHTML($page['tag'])." &mdash; ".$page['time'];
 			$result_page_list .= "\n<blockquote>".$matchText."</blockquote>\n";
 			$result_page_list .= "\n</li>\n";
 		}

--- a/actions/title/title.php
+++ b/actions/title/title.php
@@ -1,3 +1,3 @@
 <?php
-echo $this->PageTitle();
+echo $this->PageTitleHTML();
 ?>

--- a/handlers/backlinks/backlinks.php
+++ b/handlers/backlinks/backlinks.php
@@ -50,7 +50,7 @@ switch(TRUE)
 			// name change, interface change (active pages only)
 			if ($this->existsPage($tag) && $this->HasAccess('read', $tag))
 			{			
-				print $this->Link($page['page_tag']).'<br />';
+				print $this->Link($page['page_tag']).' &mdash; '.$this->PageTitle($page['page_tag'], "").'<br />';
 			}
 		}
 	}

--- a/handlers/backlinks/backlinks.php
+++ b/handlers/backlinks/backlinks.php
@@ -50,7 +50,7 @@ switch(TRUE)
 			// name change, interface change (active pages only)
 			if ($this->existsPage($tag) && $this->HasAccess('read', $tag))
 			{			
-				print $this->Link($page['page_tag']).' &mdash; '.$this->PageTitle($page['page_tag'], "").'<br />';
+				print $this->Link($page['page_tag']).' &mdash; '.$this->PageTitleHTML($page['page_tag'], "").'<br />';
 			}
 		}
 	}

--- a/handlers/html/html.php
+++ b/handlers/html/html.php
@@ -5,7 +5,7 @@ if ($this->HasAccess("read") && $this->page) {
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html>
 <head>
-    <title><?php echo $this->PageTitle(); ?></title>
+    <title><?php echo $this->PageTitleHTML(); ?></title>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
     <style type="text/css">
 		<?php include($this->GetThemePath('/','html')."/css/html.css"); ?>

--- a/handlers/maintenance.xml/maintenance.xml.php
+++ b/handlers/maintenance.xml/maintenance.xml.php
@@ -23,7 +23,7 @@
  */
 header('Content-type: text/plain; charset=utf-8');
 
-if ($this->HasAccess("write") && $this->HasAccess("read") && $this->page)
+if ($this->IsAdmin())
 {
 
 	/**
@@ -61,7 +61,13 @@ if ($this->HasAccess("write") && $this->HasAccess("read") && $this->page)
 			$page_title = $wakka->ParsePageTitle($body);
 			if ('' == $page_title)
 			{
-				$page_title = trim(preg_replace('![A-Z]!', " \\0", $tag));
+				// Automatically split camel case to a words i.e. "PageIndex" => "Page Index"
+				//
+				// $page_title = trim(preg_replace('![A-Z]!', " \\0", $tag));
+				//
+
+				// If no title was given in the body, just use the tag name
+				$page_title = $tag;
 			}
 			$wakka->Query("UPDATE ".$wakka->GetConfigValue('table_prefix')."pages set title = :page_title WHERE tag = :tag and latest = 'Y'",
 				array(':page_title' => $page_title,
@@ -71,13 +77,13 @@ if ($this->HasAccess("write") && $this->HasAccess("read") && $this->page)
 		echo "Done.";
 	}
 
-	$task = 'update';
+	$task = '';
 
 	// $task=update or $task=clear ?
 	if (isset($_GET['task']))
 	{
 		$a = $this->GetSafeVar('task', 'get');
-		if ($a == 'clear')
+		if ($a == 'clear' || $a == 'update')
 		{
 			$task = $a;
 		}

--- a/handlers/maintenance.xml/maintenance.xml.php
+++ b/handlers/maintenance.xml/maintenance.xml.php
@@ -11,36 +11,85 @@
  *
  * This handler can then be called through Cron job, or called directly
  * using an URL like http://example.com/wikka.php?wakka=HomePage/maintenance.xml
+ * 
+ *
+ * 
+ *
+ * Usage:
+ *    wikka.php?wakka=<pagename>/maintenance.xml
+ *    wikka.php?wakka=<pagename>/maintenance.xml&task=clear
+ *    wikka.php?wakka=<pagename>/maintenance.xml&task=update
+
  */
 header('Content-type: text/plain; charset=utf-8');
-/**
- * Update the title value of wikka_pages upon upgrading the wiki to version 1.3.3
- * @uses Wakka::LoadAll()
- * @uses Wakka::LoadPage()
- * @uses Wakka::ParsePageTitle()
- * @uses Wakka::Query()
- *
- */
-function UpdatePageTitle(&$wakka, $limit = 100)
-{
-	$tobeupdated = $wakka->LoadAll("select tag from ".$wakka->GetConfigValue('table_prefix')."pages where title='' and latest='Y' LIMIT ".intval($limit));
-	foreach ($tobeupdated as $no_title)
-	{
-		set_time_limit(20);
-		$tag = $no_title['tag'];
-		$page = $wakka->LoadPage($tag);
-		$body = $page['body'];
-		$page_title = $wakka->ParsePageTitle($body);
-		if ('' == $page_title)
-		{
-			$page_title = trim(preg_replace('![A-Z]!', " \\0", $tag));
-		}
-		$wakka->Query("UPDATE ".$wakka->GetConfigValue('table_prefix')."pages set title = :page_title WHERE tag = :tag and latest = 'Y'",
-			array(':page_title' => $page_title,
-			      ':tag' => $tag));
-		echo "$tag $page_title \n";
-	}
-	echo "Done...";
-}
 
-UpdatePageTitle($this);
+if ($this->HasAccess("write") && $this->HasAccess("read") && $this->page)
+{
+
+	/**
+	 * Clear all latest page titles to prepare for updating
+	 * @uses Wakka::Query()
+	 *
+	 */
+	function ClearPageTitles(&$wakka)
+	{
+		echo "Clearing Titles ...\n";
+		$wakka->Query("UPDATE ".$wakka->GetConfigValue('table_prefix')."pages set title = '' WHERE latest = 'Y'");
+		echo "Titles Cleared.";
+	}
+
+	/**
+	 * Update the title value of wikka_pages upon upgrading the wiki to version 1.3.3
+	 * @uses Wakka::LoadAll()
+	 * @uses Wakka::LoadPage()
+	 * @uses Wakka::ParsePageTitle()
+	 * @uses Wakka::Query()
+	 *
+	 */
+	function UpdatePageTitle(&$wakka, $limit = 100)
+	{
+		echo "Updating Titles ...\n";
+		echo "Refresh page until task is complete \n\n";
+
+		$tobeupdated = $wakka->LoadAll("select tag from ".$wakka->GetConfigValue('table_prefix')."pages where title='' and latest='Y' LIMIT ".intval($limit));
+		foreach ($tobeupdated as $no_title)
+		{
+			set_time_limit(20);
+			$tag = $no_title['tag'];
+			$page = $wakka->LoadPage($tag);
+			$body = $page['body'];
+			$page_title = $wakka->ParsePageTitle($body);
+			if ('' == $page_title)
+			{
+				$page_title = trim(preg_replace('![A-Z]!', " \\0", $tag));
+			}
+			$wakka->Query("UPDATE ".$wakka->GetConfigValue('table_prefix')."pages set title = :page_title WHERE tag = :tag and latest = 'Y'",
+				array(':page_title' => $page_title,
+				      ':tag' => $tag));
+			echo "$tag $page_title \n";
+		}
+		echo "Done.";
+	}
+
+	$task = 'update';
+
+	// $task=update or $task=clear ?
+	if (isset($_GET['task']))
+	{
+		$a = $this->GetSafeVar('task', 'get');
+		if ($a == 'clear')
+		{
+			$task = $a;
+		}
+	}
+
+	if ($task == 'clear')
+	{
+		ClearPageTitles($this);
+	}
+
+	if ($task == 'update')
+	{
+		UpdatePageTitle($this, 1000);
+	}
+}

--- a/lang/en/defaults/_WikkaMenulets.php
+++ b/lang/en/defaults/_WikkaMenulets.php
@@ -670,7 +670,7 @@ Prints the title of the current page: {{title}}
 
 %%(php)
 <?php
-echo $this->PageTitle();
+echo $this->PageTitleHTML();
 ?>
 %%
 

--- a/libs/Wakka.class.php
+++ b/libs/Wakka.class.php
@@ -2204,7 +2204,7 @@ class Wakka
 	 * @param	string	@tag	optional: page to get title for (default current page)
 	 * @return	mixed	the title of the current page or the page name if none found, trimmed
 	 */
-	function PageTitle($tag=null)
+	function PageTitle($tag=null, $prefix=NULL)
 	{
 		if ($tag === null)
 		{
@@ -2220,13 +2220,27 @@ class Wakka
 					"pages WHERE tag = :tag
 					AND LATEST = 'Y'";
 			$res = $this->LoadSingle($query, array(':tag' => $tag));
-			$page_title = trim($res['title']) !== '' ? $res['title'] : $tag;
+			if ($res)
+			{
+				$page_title = trim($res['title']) !== '' ? $res['title'] : $tag;
+			}
+			else
+			{
+				$page_title = "Invalid Page Name";
+			}
 			$page_title = strip_tags($page_title);
 		}
 		$handler = $this->GetHandler();
-		if($handler != 'show' &&
-		   $handler != NULL) {
-			$page_title = $handler." \"".trim($page_title)."\"";
+		if($handler != NULL && $handler != 'show')
+		{
+			if ($prefix === NULL)
+			{
+				$page_title = $handler." \"".trim($page_title)."\"";
+			}
+			else
+			{
+				$page_title = $prefix."\"".trim($page_title)."\"";
+			}
 		}
 		return $page_title;
 	}
@@ -2253,6 +2267,7 @@ class Wakka
 		{
 			list($h_fullmatch, $h_heading) = $matches;
 			$page_title = $this->SetPageTitle($h_heading);
+			return trim(strip_tags($page_title));
 		}
 		elseif (preg_match("#(={3,6})([^=].*?)\\1#s", $body, $matches))
 		{

--- a/libs/Wakka.class.php
+++ b/libs/Wakka.class.php
@@ -2246,6 +2246,20 @@ class Wakka
 	}
 
 	/**
+	 * Return the title of the current page safe for HTML
+	 *
+	 * @uses	Wakka::PageTitle()
+	 *
+	 *
+	 * @param	string	@tag	optional: page to get title for (default current page)
+	 * @return	mixed	the title of the current page or the page name if none found, trimmed
+	 */
+	function PageTitleHTML($tag=null, $prefix=NULL)
+	{
+		return $this->htmlspecialchars_ent($this->PageTitle($tag,$prefix));
+	}
+
+	/**
 	 * Parses the body of a page for a page title
 	 *
 	 * Searches for first instance of header markup in page body and
@@ -2950,7 +2964,7 @@ class Wakka
 			}
 			if ($options['show_page_title'])
 			{
-				$output_page_title = ' <span class="pagetitle">['.$this->PageTitle($val).']</span>';
+				$output_page_title = ' <span class="pagetitle">['.$this->PageTitleHTML($val).']</span>';
 			}
 			if ($options['compact'])
 			{

--- a/templates/classic/header.php
+++ b/templates/classic/header.php
@@ -14,7 +14,7 @@ if ( substr_count($site_base, 'wikka.php?wakka=') > 0 ) $site_base = substr($sit
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<title><?php echo $this->PageTitle()." - ".$this->GetWakkaName(); ?></title>
+	<title><?php echo $this->PageTitleHTML()." - ".$this->GetWakkaName(); ?></title>
 	<base href="<?php echo $site_base ?>" />
 <?php if ($this->GetHandler() != 'show' || $this->page["latest"] == 'N' || $this->page["tag"] == 'SandBox') echo "<meta name=\"robots\" content=\"noindex, nofollow, noarchive\" />\n"; ?>
 	<meta name="generator" content="WikkaWiki" />
@@ -55,7 +55,7 @@ if (isset($message) && strlen($message)>0)
 ?>
 <!-- BEGIN PAGE HEADER -->
 <div id="header">
-<h1><a href="<?php echo $this->href('backlinks', '', ''); ?>" title="Display a list of pages linking to <?php echo $this->GetPageTag() ?>"><?php echo $this->PageTitle(); ?></a> - <a id="homepage_link" href="<?php echo $this->href('', $this->GetConfigValue('root_page'), ''); ?>"><?php echo $this->GetWakkaName();?></a></h1>
+<h1><a href="<?php echo $this->href('backlinks', '', ''); ?>" title="Display a list of pages linking to <?php echo $this->GetPageTag() ?>"><?php echo $this->PageTitleHTML(); ?></a> - <a id="homepage_link" href="<?php echo $this->href('', $this->GetConfigValue('root_page'), ''); ?>"><?php echo $this->GetWakkaName();?></a></h1>
 <?php echo $this->MakeMenu('main_menu'); ?>
 </div>
 <div>

--- a/templates/kubrick/header.php
+++ b/templates/kubrick/header.php
@@ -14,7 +14,7 @@ if ( substr_count($site_base, 'wikka.php?wakka=') > 0 ) $site_base = substr($sit
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<title><?php echo $this->PageTitle().": ".$this->GetWakkaName(); ?></title>
+	<title><?php echo $this->PageTitleHTML().": ".$this->GetWakkaName(); ?></title>
 	<base href="<?php echo $site_base ?>" />
 <?php if ($this->GetHandler() != 'show' || $this->page["latest"] == 'N' || $this->page["tag"] == 'SandBox') echo "<meta name=\"robots\" content=\"noindex, nofollow, noarchive\" />\n"; ?>
 	<meta name="generator" content="WikkaWiki" />

--- a/templates/light/header.php
+++ b/templates/light/header.php
@@ -14,7 +14,7 @@ if ( substr_count($site_base, 'wikka.php?wakka=') > 0 ) $site_base = substr($sit
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<title><?php echo $this->PageTitle().":".$this->GetWakkaName(); ?></title>
+	<title><?php echo $this->PageTitleHTML().":".$this->GetWakkaName(); ?></title>
 	<base href="<?php echo $site_base ?>" />
 <?php if ($this->GetHandler() != 'show' || $this->page["latest"] == 'N' || $this->page["tag"] == 'SandBox') echo "<meta name=\"robots\" content=\"noindex, nofollow, noarchive\" />\n"; ?>
 	<meta name="generator" content="WikkaWiki" />


### PR DESCRIPTION
Fixes #3
- Titles on wiki pages are missing leading underscores
